### PR TITLE
Add invertedIconLogic prop - Fixes issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Property | Description
 :--- | :---
 `isDark`|Boolean value to set the `aria-label` and `title` attributes according to the theme.
 `onChange`|Function to fire when the button is toggled.
+`invertedIconLogic`|if true, it will show the icon of the current mode e.g. if isDark=true it will show the moon instead of the sun. (defaults to false)
 -----
 
 ## Styling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-theme-toggle-button",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ exports[`ReactThemeToggleButton renders correctly 1`] = `
   title="Activate light mode"
 >
   <input
+    defaultChecked={true}
     onChange={[Function]}
     type="checkbox"
   />

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,26 @@
 import React from "react";
 import styles from "./styles.module.css";
 
-const ReactThemeToggleButton = ({ isDark, onChange }) => (
+const defaultOptions = {
+  invertedIconLogic: false,
+};
+
+const ReactThemeToggleButton = ({
+  isDark,
+  onChange,
+  invertedIconLogic = defaultOptions.invertedIconLogic,
+}) => (
   // eslint-disable-next-line jsx-a11y/label-has-associated-control
   <label
     className={styles.container}
     title={isDark ? "Activate light mode" : "Activate dark mode"}
     aria-label={isDark ? "Activate light mode" : "Activate dark mode"}
   >
-    <input type="checkbox" onChange={onChange} />
+    <input
+      type="checkbox"
+      defaultChecked={invertedIconLogic ? !isDark : isDark}
+      onChange={onChange}
+    />
     <div />
   </label>
 );

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import renderer from "react-test-renderer";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import ReactThemeToggleButton from "./index";
 
 describe("ReactThemeToggleButton", () => {
@@ -54,6 +54,16 @@ describe("ReactThemeToggleButton", () => {
       fireEvent.click(getByTitle(/activate/i));
 
       expect(onChangeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("when `invertIconLogic` prop is true", () => {
+    it("inverts icon logic", () => {
+      render(
+        <ReactThemeToggleButton isDark onChange={() => {}} invertedIconLogic />
+      );
+
+      expect(screen.getByRole("checkbox")).not.toBeChecked();
     });
   });
 });


### PR DESCRIPTION
Added `invertedIconLogic` prop which defaults to `false`.

**Changes**
- Added prop to Readme
- Added unit test
- Added `defaultChecked` to implement the `invertedIconLogic` prop
- Updated snapshot because of the added `defaultChecked` prop

**Comments**
- As it's the only option, I think it's OK to directly add it to the component no need to pass it as `options` prop. `<ToggleButton isDark={isDark} invertedIconLogic />`
- I think the name of the prop is OK as it's clear what it will do, right? 
- Example in the repo not updated - is it required?
- I'm new to React-Testing lib. Is the test for the new prop OK?

**Todos**
- [ ] `defaultChecked` vs `checked`? With `defaultChecked` it is not possible to change the logic during runtime. I've mainly changed it because there was a warning during testing because `onChange` was missing in a test. I'll fix that test and change to `checked` as I think this would be better.

**Fixes issue #5**